### PR TITLE
Bugfix/bad results on full production input document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ notes.js
 *.sw?
 
 notes.md
+cleaning cz.pdf
+cleaning eng.pdf

--- a/src/components/FileHandler/importUtils.js
+++ b/src/components/FileHandler/importUtils.js
@@ -10,6 +10,7 @@ export function isRoomNumberAsString(value) {
 
 export function parseRow(row) {
   let parsedRow = [];
+  let hasTimeCodeCell = false;
   for (const element of row) {
     let cell = element;
 
@@ -18,8 +19,12 @@ export function parseRow(row) {
     const isCellRelevant =
       (cell && isRoomNumberAsString(cell)) ||
       isCleanlinessStatus(cell) ||
-      isTimeCode(cell) ||
       isAvailability(cell);
+
+    if (isTimeCode(cell) && !hasTimeCodeCell) {
+      hasTimeCodeCell = true;
+      parsedRow.push(cell);
+    }
 
     if (isCellRelevant) parsedRow.push(cell);
   }
@@ -36,13 +41,14 @@ export function parseRow(row) {
     // matches for available or till mm.dd. in English and Czech
     // permits single or double digit day.month as
     const regexEnglish = /^(available|till \d{1,2}\.\d{1,2})$/;
-    const regexCzech = /^(volný|volny|do \d{1,2}\.\d{1,2})$/;
+    const regexCzech = /^(volný|volny|v o l n ý|do \d{1,2}\.\d{1,2})$/;
     return regexCzech.test(cell) || regexEnglish.test(cell);
   }
 }
 
 export function isTimeCode(cell) {
   // matches D, Q, or O followed by either two capital letters or a capital letter and a number
+  // it would be better to have a more precise regex to match against only known timeCodes
   const regex = /^(D|Q|O)([A-Z]{2}|[A-Z]\d)$/;
   return regex.test(cell);
 }
@@ -76,7 +82,6 @@ export async function convertToJson(file) {
 
 export function addAvailabilityStatusToRooms(rooms = []) {
   for (const room of rooms) room.push(getRoomState(room));
-
   return rooms;
 
   function getRoomState(room) {

--- a/src/components/FileHandler/importUtils.js
+++ b/src/components/FileHandler/importUtils.js
@@ -92,7 +92,8 @@ export function addAvailabilityStatusToRooms(rooms = []) {
     const isRoomVacant =
       room.includes('available') ||
       room.includes('volný') ||
-      room.includes('volny');
+      room.includes('volny') ||
+      room.includes('v o l n ý');
 
     if (isUncleanedLeftoverRoom || (dateString && isDeparture(dateString))) {
       return ROOM_STATES.DEPARTURE;


### PR DESCRIPTION
Two bugfixes
1. related to an additional cell being appended that doesn't belong. TimeCode regex was matching again for 'DEU' country code, so we had two timeCode cells, which throws off the expected data structure
2. input dating has some weird whitespace issue that was affecting the matching for 'volny'. A sanitizing operation like below would be nice but its fastest and easiest to just include another case in the condition: `room.includes('v o l n y')`

```
if (
      typeof room[2] === 'string' &&
      room[2].trim() !== '' &&
      room[2][0] === 'v'
    ) {
      const trimmedRoomState = room[2].split(' ').join('');
    }
```
